### PR TITLE
Update font information in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-#hacklab-fi
+# hacklab-fi
 
 Promotional material for http://hacklab.fi
 
-##Style Guide
+## Style Guide
 
-Font in the logo is Droid Sans (bold), https://www.google.com/fonts/specimen/Droid+Sans
+Font in the logo is Droid Sans (bold). Droid Sans has been replaced by Noto Sans (a new font based on Droid Sans) after the creation of the logo.
 
-We'll use Noto Sans for normal text, https://www.google.com/fonts/specimen/Noto+Sans
+Use Noto Sans for normal text (bold for headings). https://www.google.com/fonts/specimen/Noto+Sans
 
-For monospace (code etc) use Inconsolata, https://www.google.com/fonts/specimen/Inconsolata
+For monospace (code etc) use Inconsolata. https://www.google.com/fonts/specimen/Inconsolata


### PR DESCRIPTION
Noto Sans and Droid Sans are not two separate fonts, as the README previously implied. Noto Sans was just created by taking the Latin alphabet from Droid Sans (and then creating new similar fonts for other writing systems).

Droid Sans link is removed because Google no longer has it, and the Noto Sans link serves the same purpose.

Also fixed broken Markdown syntax in the file.